### PR TITLE
Fix OpenAI error handling and env var bug

### DIFF
--- a/gpt_dj.py
+++ b/gpt_dj.py
@@ -2,6 +2,7 @@
 
 import os
 import openai
+from openai import OpenAIError
 import requests
 import logging
 from dotenv import load_dotenv
@@ -84,9 +85,13 @@ class RadioFreeDJ:
                 messages=messages
             )
             return response.choices[0].message.content.strip()
-        except Exception as e:
+        except OpenAIError as e:
             self.logger.error(f"OpenAI request failed: {e}")
             console.print(Panel(str(e), title="❌ GPT API Error", border_style="red"))
+            return "[gpt-error]"
+        except Exception as e:
+            self.logger.error(f"Unexpected error during OpenAI call: {e}")
+            console.print(Panel(str(e), title="❌ GPT Error", border_style="red"))
             return "[gpt-error]"
 
 

--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ def log_gpt(prompt: str, response: str):
 
 # === instantiate radiofreedj ===
 api_key = os.getenv("OPENAI_API_KEY")
-gpt_model = os.getenv("gpt_model", "gpt-4o-mini")
+gpt_model = os.getenv("GPT_MODEL", "gpt-4o-mini")
 if not api_key:
     raise ValueError("OPENAI_API_KEY is not set in .env!")
 


### PR DESCRIPTION
## Summary
- use correct `GPT_MODEL` env var in `main.py`
- handle `OpenAIError` separately in `gpt_dj`'s OpenAI call

## Testing
- `python -m py_compile main.py gpt_dj.py`
- `python -m py_compile gpt_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68439173643c8329ae6dd01297e561d1