### PR TITLE
Fix OpenAI error handling and env var bug

### DIFF
--- a/genius_utils.py
+++ b/genius_utils.py
@@ -1,10 +1,13 @@
 import os
+import logging
 import lyricsgenius
 from dotenv import load_dotenv
+from logger_utils import setup_logger
 
 load_dotenv()
 
 GENIUS_TOKEN = os.getenv("GENIUS_API_TOKEN")
+logger = setup_logger(__name__)
 
 genius = lyricsgenius.Genius(
     GENIUS_TOKEN, skip_non_songs=True, excluded_terms=["(Remix)", "(Live)"], timeout=10
@@ -21,5 +24,5 @@ def get_lyrics(song_name, artist_name):
             return song.lyrics
         return None
     except Exception as e:
-        print(f"[Genius Error] {e}")
+        logger.error("Genius error: %s", e)
         return None

--- a/gpt_dj.py
+++ b/gpt_dj.py
@@ -2,6 +2,7 @@
 
 import os
 import openai
+from openai import OpenAIError
 import requests
 import logging
 from dotenv import load_dotenv
@@ -84,9 +85,13 @@ class RadioFreeDJ:
                 messages=messages
             )
             return response.choices[0].message.content.strip()
-        except Exception as e:
+        except OpenAIError as e:
             self.logger.error(f"OpenAI request failed: {e}")
             console.print(Panel(str(e), title="❌ GPT API Error", border_style="red"))
+            return "[gpt-error]"
+        except Exception as e:
+            self.logger.error(f"Unexpected error during OpenAI call: {e}")
+            console.print(Panel(str(e), title="❌ GPT Error", border_style="red"))
             return "[gpt-error]"
 
 

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,9 +1,11 @@
-import os
+import logging
 import tiktoken
 from rich.console import Console
 from rich.panel import Panel
+from logger_utils import setup_logger
 
 console = Console()
+logger = setup_logger(__name__)
 
 
 def count_tokens(prompt, active_model):
@@ -11,19 +13,17 @@ def count_tokens(prompt, active_model):
         encoding = tiktoken.encoding_for_model(active_model)
         return len(encoding.encode(prompt))
     except Exception as e:
+        logger.error("Token count error: %s", e)
         console.print(Panel(str(e), title=" Token Count Error", border_style="red"))
         return len(prompt.split())
 
 
-def log_request(prompt, active_model, token_count, log_path="radio.log"):
+def log_request(prompt, active_model, token_count):
     try:
-        log_path = os.path.abspath(log_path)
-        with open(log_path, "a") as log_file:
-            log_file.write(f"\n--- RadioFreeGPT Request ---\n")
-            log_file.write(f"Model: {active_model}\n")
-            log_file.write(f"Prompt:\n{prompt}\n")
-            log_file.write(f"Tokens used: {token_count}\n")
-            log_file.write(f"-----------------------------\n")
-        console.print(f"[green] Logged request to:[/green] {log_path}")
+        logger.info("--- RadioFreeGPT Request ---")
+        logger.info("Model: %s", active_model)
+        logger.info("Prompt:\n%s", prompt)
+        logger.info("Tokens used: %s", token_count)
     except Exception as e:
+        logger.error("Log write error: %s", e)
         console.print(Panel(str(e), title=" Log Write Error", border_style="red"))

--- a/logger_utils.py
+++ b/logger_utils.py
@@ -3,17 +3,20 @@
 import logging
 import os
 
-# logfile = os.path.resolve().parent(__file__).parent / log_path
+# Default log path within the repository root
+LOG_PATH = os.path.join(os.path.dirname(__file__), "requests.log")
 
-def setup_logger(name: str, log_path: str = "./logs/requests.log") -> logging.Logger:
+
+def setup_logger(name: str, log_path: str | None = None) -> logging.Logger:
     """
     Set up and return a logger with the given name and log file path.
     """
     logger = logging.getLogger(name)
+    if log_path is None:
+        log_path = LOG_PATH
     if not logger.handlers:
-        os.makedirs(os.path.dirname(log_path), exist_ok=True) if os.path.dirname(
-            log_path
-        ) else None
+        if os.path.dirname(log_path):
+            os.makedirs(os.path.dirname(log_path), exist_ok=True)
         handler = logging.FileHandler(log_path)
         formatter = logging.Formatter("[%(asctime)s] %(levelname)s: %(message)s")
         handler.setFormatter(formatter)

--- a/lyrics_sync.py
+++ b/lyrics_sync.py
@@ -5,14 +5,9 @@ from rich.text import Text
 from genius_utils import get_lyrics
 import requests
 from requests.exceptions import RequestException
-import logging
+from logger_utils import setup_logger
 
-# logging.basicConfig(
-#     level=logging.DEBUG,
-#     format="%(asctime)s %(name)s %(levelname)s: %(message)s",
-# )
-
-logging.disable(logging.CRITICAL)
+logger = setup_logger(__name__)
 
 
 class LyricsSyncManager:
@@ -23,7 +18,7 @@ class LyricsSyncManager:
         self.timestamps = []
         self.lines = []
         self.current_index = 0
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logger
 
     def start(self, track_name, artist_name, album_name="", duration_ms=0):
         self.current_index = 0

--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ def log_gpt(prompt: str, response: str):
 
 # === instantiate radiofreedj ===
 api_key = os.getenv("OPENAI_API_KEY")
-gpt_model = os.getenv("gpt_model", "gpt-4o-mini")
+gpt_model = os.getenv("GPT_MODEL", "gpt-4o-mini")
 if not api_key:
     raise ValueError("OPENAI_API_KEY is not set in .env!")
 

--- a/spotify_utils.py
+++ b/spotify_utils.py
@@ -1,9 +1,9 @@
 # spotify_utils.py
 
-import os
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 from dotenv import load_dotenv
+from logger_utils import setup_logger
 
 # Load environment variables
 load_dotenv()
@@ -26,6 +26,7 @@ class SpotifyController:
                 redirect_uri=os.getenv("SPOTIPY_REDIRECT_URI"),
             )
         )
+        self.logger = setup_logger(self.__class__.__name__)
 
     def get_current_song(self):
         try:
@@ -36,7 +37,7 @@ class SpotifyController:
             artist_name = current["item"]["artists"][0]["name"]
             return song_name, artist_name
         except Exception as e:
-            print(f"Error fetching current song: {e}")
+            self.logger.error("Error fetching current song: %s", e)
             return None, None
 
     def search_track(self, track_name, artist_name):
@@ -46,91 +47,91 @@ class SpotifyController:
             tracks = result.get("tracks", {}).get("items", [])
             return tracks[0]["uri"] if tracks else None
         except Exception as e:
-            print(f"Error searching track: {e}")
+            self.logger.error("Error searching track: %s", e)
             return None
 
     def play_track(self, track_uri):
         try:
             devices = self.sp.devices().get('devices', [])
             if not devices:
-                print("No active Spotify device.")
+                self.logger.warning("No active Spotify device")
                 return
             device_id = devices[0]['id']
             self.sp.transfer_playback(device_id, force_play=True)
             self.sp.start_playback(uris=[track_uri])
         except Exception as e:
-            print(f"Error playing track: {e}")
+            self.logger.error("Error playing track: %s", e)
 
     def pause(self):
         try:
             self.sp.pause_playback()
         except Exception as e:
-            print(f"Error pausing: {e}")
+            self.logger.error("Error pausing: %s", e)
 
     def resume(self):
         try:
             self.sp.start_playback()
         except Exception as e:
-            print(f"Error resuming: {e}")
+            self.logger.error("Error resuming: %s", e)
 
     def next(self):
         try:
             self.sp.next_track()
         except Exception as e:
-            print(f"Error skipping: {e}")
+            self.logger.error("Error skipping: %s", e)
 
     def previous(self):
         try:
             self.sp.previous_track()
         except Exception as e:
-            print(f"Error going back: {e}")
+            self.logger.error("Error going back: %s", e)
 
     def set_volume(self, vol_percent):
         try:
             self.sp.volume(vol_percent)
         except Exception as e:
-            print(f"Error setting volume: {e}")
+            self.logger.error("Error setting volume: %s", e)
 
     def add_to_queue(self, track_uri):
         try:
             self.sp.add_to_queue(track_uri)
         except Exception as e:
-            print(f"Error adding to queue: {e}")
+            self.logger.error("Error adding to queue: %s", e)
 
     def pause(self):
         try:
             self.sp.pause_playback()
         except Exception as e:
-            print(f"Error pausing playback: {e}")
+            self.logger.error("Error pausing playback: %s", e)
 
     def resume(self):
         try:
             self.sp.start_playback()
         except Exception as e:
-            print(f"Error resuming playback: {e}")
+            self.logger.error("Error resuming playback: %s", e)
 
     def next_track(self):
         try:
             self.sp.next_track()
         except Exception as e:
-            print(f"Error skipping to next track: {e}")
+            self.logger.error("Error skipping to next track: %s", e)
 
     def previous_track(self):
         try:
             self.sp.previous_track()
         except Exception as e:
-            print(f"Error going to previous track: {e}")
+            self.logger.error("Error going to previous track: %s", e)
 
     def change_volume(self, delta):
         try:
             playback = self.sp.current_playback()
             if not playback or "device" not in playback:
-                print("No active device.")
+                self.logger.warning("No active device")
                 return
             current_vol = playback["device"]["volume_percent"]
             new_vol = min(100, max(0, current_vol + delta))
             self.sp.volume(new_vol)
-            print(f"🔊 Volume set to {new_vol}%")
+            self.logger.info("Volume set to %d%%", new_vol)
         except Exception as e:
-            print(f"Error changing volume: {e}")
+            self.logger.error("Error changing volume: %s", e)
     

--- a/view_history.py
+++ b/view_history.py
@@ -5,13 +5,15 @@ import os
 from datetime import datetime
 from rich.console import Console
 from rich.table import Table
+from logger_utils import setup_logger
 
 HISTORY_FILE = os.path.expanduser("~/RadioFree/logs/song_history.jsonl")
+logger = setup_logger(__name__)
 
 def load_history():
     """Load song history entries from the JSONL file."""
     if not os.path.exists(HISTORY_FILE):
-        print("No song history found.")
+        logger.info("No song history found")
         return []
 
     with open(HISTORY_FILE, "r") as f:


### PR DESCRIPTION
## Summary
- use correct `GPT_MODEL` env var in `main.py`
- handle `OpenAIError` separately in `gpt_dj`'s OpenAI call
- unify logger usage across modules

## Testing
- `python -m py_compile main.py gpt_dj.py gpt_utils.py logger_utils.py spotify_utils.py genius_utils.py lyrics_sync.py upnext.py view_history.py`


------
https://chatgpt.com/codex/tasks/task_e_68439173643c8329ae6dd01297e561d1