### PR TITLE
Refactor spotify utils methods

### DIFF
--- a/main.py
+++ b/main.py
@@ -400,10 +400,10 @@ def process_user_input(choice: str, current_song: str, current_artist: str):
             spotify_controller.resume()
             notify("▶️ Resumed playback", style="yellow")
     elif choice == "next":
-        spotify_controller.next_track()
+        spotify_controller.next()
         notify("⏭ Skipped to next track.", style="yellow")
     elif choice == "prev":
-        spotify_controller.previous_track()
+        spotify_controller.previous()
         notify("⏮ Went back to previous track.", style="yellow")
     elif choice == "vol_up":
         spotify_controller.change_volume(+10)

--- a/spotify_utils.py
+++ b/spotify_utils.py
@@ -1,4 +1,8 @@
-# spotify_utils.py
+"""Utilities for controlling Spotify playback via the Spotipy client.
+
+This module exposes :class:`SpotifyController`, a thin wrapper that provides
+methods for playing tracks, adjusting volume and managing the playback queue.
+"""
 import os
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
@@ -10,6 +14,7 @@ load_dotenv()
 
 
 class SpotifyController:
+    """Wrapper around Spotipy exposing common playback controls."""
     def __init__(self):
         self.sp = spotipy.Spotify(
             auth_manager=SpotifyOAuth(
@@ -62,24 +67,28 @@ class SpotifyController:
             self.logger.error("Error playing track: %s", e)
 
     def pause(self):
+        """Pause the currently playing track."""
         try:
             self.sp.pause_playback()
         except Exception as e:
             self.logger.error("Error pausing: %s", e)
 
     def resume(self):
+        """Resume playback on the active device."""
         try:
             self.sp.start_playback()
         except Exception as e:
             self.logger.error("Error resuming: %s", e)
 
     def next(self):
+        """Skip to the next track."""
         try:
             self.sp.next_track()
         except Exception as e:
             self.logger.error("Error skipping: %s", e)
 
     def previous(self):
+        """Return to the previous track."""
         try:
             self.sp.previous_track()
         except Exception as e:
@@ -97,29 +106,6 @@ class SpotifyController:
         except Exception as e:
             self.logger.error("Error adding to queue: %s", e)
 
-    def pause(self):
-        try:
-            self.sp.pause_playback()
-        except Exception as e:
-            self.logger.error("Error pausing playback: %s", e)
-
-    def resume(self):
-        try:
-            self.sp.start_playback()
-        except Exception as e:
-            self.logger.error("Error resuming playback: %s", e)
-
-    def next_track(self):
-        try:
-            self.sp.next_track()
-        except Exception as e:
-            self.logger.error("Error skipping to next track: %s", e)
-
-    def previous_track(self):
-        try:
-            self.sp.previous_track()
-        except Exception as e:
-            self.logger.error("Error going to previous track: %s", e)
 
     def change_volume(self, delta):
         try:


### PR DESCRIPTION
## Summary
- remove duplicate playback methods from `spotify_utils.py`
- document `SpotifyController` and its control helpers
- call `next()`/`previous()` from main instead of removed names

## Testing
- `python -m py_compile spotify_utils.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6849b8fc1104832992a62ae11c9f9a1e