### PR TITLE
Add queue maintenance mode

### DIFF
--- a/docs/auto_dj.md
+++ b/docs/auto_dj.md
@@ -1,13 +1,13 @@
 # Auto-DJ Command
 
-The **Auto-DJ** feature lets RadioFreeDJ automatically select and queue the next track using GPT. When you press **`1`** in the menu, the program:
+The **Auto-DJ** feature can keep the queue populated with GPT suggestions. Press **`1`** to toggle the mode. When enabled, the program will:
 
 1. Builds a prompt from `prompts.json` under the `auto_dj` key.
 2. Sends the prompt to the configured GPT model via `RadioFreeDJ.ask`.
 3. Expects a JSON response containing `track_name` and `artist_name`.
 4. Searches Spotify for the track and queues it if found.
-5. Generates a short radio‑style intro for the queued track using the `generate_radio_intro` prompt and prints it in the console.
+5. Generate a short radio‑style intro for each queued track using the `generate_radio_intro` prompt and print it in the console.
 
-If the response cannot be parsed or the track isn't found, a warning is logged and nothing is queued.
+If the response cannot be parsed or the track isn't found, a warning is logged and nothing is queued. Recently played tracks are remembered so the DJ avoids immediate repeats.
 
-This command integrates GPT recommendations with the real Spotify queue so that the station keeps playing new songs without manual search.
+When Auto-DJ is turned off, no additional songs are queued automatically.

--- a/main.py
+++ b/main.py
@@ -375,7 +375,11 @@ def process_user_input(choice: str, current_song: str, current_artist: str):
     elif choice == "0":
         raise KeyboardInterrupt
     elif choice == "1":
-        upnext.auto_dj_transition(current_song, current_artist)
+        upnext.auto_dj_enabled = not upnext.auto_dj_enabled
+        state = "enabled" if upnext.auto_dj_enabled else "disabled"
+        notify(f"Auto-DJ {state}", style="cyan")
+        if upnext.auto_dj_enabled:
+            upnext.maintain_queue(current_song, current_artist)
     elif choice == "2":
         upnext.queue_one_song(current_song, current_artist)
     elif choice == "3":
@@ -497,7 +501,11 @@ def main():
                     notify(f"🔄 Track changed: {current_song} by {current_artist}", style="cyan")
                     lyrics_manager.start(current_song, current_artist, album_name, duration_ms)
                     sync_with_lastfm(current_song, current_artist)
+                    if upnext.auto_dj_enabled:
+                        upnext.maintain_queue(current_song, current_artist)
                 lyrics_manager.sync(progress_ms)
+                if upnext.auto_dj_enabled:
+                    upnext.maintain_queue(current_song, current_artist)
                 live.update(create_layout(current_song, current_artist))
                 if not user_input_queue.empty():
                     choice = user_input_queue.get()

--- a/tests/test_upnext.py
+++ b/tests/test_upnext.py
@@ -1,0 +1,59 @@
+import sys, os
+os.environ.setdefault("GENIUS_API_TOKEN", "dummy")
+import unittest
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from upnext import UpNextManager
+
+
+class DummyDJ:
+    def __init__(self):
+        class L:
+            def info(self, *a, **k):
+                pass
+            def warning(self, *a, **k):
+                pass
+            def error(self, *a, **k):
+                pass
+        self.logger = L()
+
+    def ask(self, prompt):
+        return '{}'
+
+
+class DummySpotify:
+    def search_track(self, track, artist):
+        return f"uri:{track}:{artist}"
+
+    def add_to_queue(self, uri):
+        pass
+
+
+class UpNextTest(unittest.TestCase):
+    def test_recent_track_skip(self):
+        mgr = UpNextManager(DummyDJ(), DummySpotify(), {})
+        mgr.recent_tracks.append(("Song", "Artist"))
+        added = mgr._queue_track("Song", "Artist")
+        self.assertFalse(added)
+
+    def test_maintain_queue_caps_length(self):
+        mgr = UpNextManager(DummyDJ(), DummySpotify(), {})
+        mgr.auto_dj_enabled = True
+        tracks = [(f"Song{i}", f"Artist{i}") for i in range(6)]
+        gen = (t for t in tracks)
+
+        def fake_auto_dj(curr_song, curr_artist):
+            try:
+                t = next(gen)
+            except StopIteration:
+                return False
+            return mgr._queue_track(*t)
+
+        mgr.auto_dj_transition = fake_auto_dj
+        mgr.maintain_queue("Current", "Artist")
+        self.assertEqual(len(mgr.queue), 5)
+        self.assertIn(("Current", "Artist"), mgr.recent_tracks)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- toggleable Auto-DJ mode with history tracking
- skip recently played tracks and keep upcoming queue to five songs
- update docs for new behaviour
- test UpNext queue maintenance logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b903d8048329b93319d1b1b77c92