### PR TITLE
Fix KeyError when toggling Auto‑DJ

### DIFF
--- a/prompts.json
+++ b/prompts.json
@@ -1,5 +1,5 @@
 {
-  "recommend_next_song": "Reference song: '{song_name}' by {artist_name}. Recommend a similar song. Respond ONLY in JSON format:\n{'track_name': '<TRACK NAME>', 'artist_name': '<ARTIST NAME>'}",
+  "recommend_next_song": "Reference song: '{song_name}' by {artist_name}. Recommend a similar song. Respond ONLY in JSON format:\n{{'track_name': '<TRACK NAME>', 'artist_name': '<ARTIST NAME>'}}",
   "recommend_next_ten_songs": "Reference song: '{song_name}' by {artist_name}. List 10 similar songs in the format:\n1. [Track Title] by [Artist Name]",
   "create_playlist": "The current song is '{song_name}' by {artist_name}. Create a playlist of 15 songs matching the same vibe.",
   "theme_based_playlist": "Create a playlist of 10 songs fitting the theme '{theme}'. Format:\n1. [Track Title] by [Artist Name]",
@@ -7,5 +7,5 @@
   "song_insights": "You are Buzz Navarro, audophile Radio Host, you know all the obscure facts and low key bands. Tell your viewers about '{song_name}' by {artist_name}. You must respond as Radio Host. Bonus points for less-known facts.",
   "lyrics_take": "You are radio host _____ {{explanation about knowledge of song lyrics}} {{instruction to explain deep meaning of song lyrics}} from {{track_name}} by {{artist_name}}",
   "explain_lyrics": "You are a thoughtful music journalist. Using the lyrics below, write a creative yet accurate interpretation of '{song_name}' by {artist_name}. Reference specific lines.\nLyrics:\n{lyrics}",
-  "auto_dj": "Current song: '{song_name}' by {artist_name}. Suggest a good follow-up track. Respond ONLY in JSON format:\n{'track_name': '<TRACK>', 'artist_name': '<ARTIST>'}"
+  "auto_dj": "Current song: '{song_name}' by {artist_name}. Suggest a good follow-up track. Respond ONLY in JSON format:\n{{'track_name': '<TRACK>', 'artist_name': '<ARTIST>'}}"
 }


### PR DESCRIPTION
## Summary
- escape literal braces in `prompts.json` so string formatting doesn't fail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b78257808329ae4f615e4d903b44