### PR TITLE
Implement DJ commentary feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -128,6 +128,7 @@ upnext = UpNextManager(gpt_dj, spotify_controller, prompt_templates)
 lyrics_manager = LyricsSyncManager(spotify_controller)
 console = Console()
 last_song = {"name": None, "artist": None, "started": 0}
+auto_dj_counter = 0
 
 # ─────────────────────────────────────────────────────────────
 # Event Notifications
@@ -501,8 +502,18 @@ def main():
                     notify(f"🔄 Track changed: {current_song} by {current_artist}", style="cyan")
                     lyrics_manager.start(current_song, current_artist, album_name, duration_ms)
                     sync_with_lastfm(current_song, current_artist)
+                    global auto_dj_counter
+                    auto_dj_counter += 1
                     if upnext.auto_dj_enabled:
                         upnext.maintain_queue(current_song, current_artist)
+                        if auto_dj_counter % 3 == 0 and upnext.queue:
+                            upnext.dj_commentary(
+                                (last_song["name"], last_song["artist"]),
+                                (
+                                    upnext.queue[0]["track_name"],
+                                    upnext.queue[0]["artist_name"],
+                                ),
+                            )
                 lyrics_manager.sync(progress_ms)
                 if upnext.auto_dj_enabled:
                     upnext.maintain_queue(current_song, current_artist)

--- a/prompts.json
+++ b/prompts.json
@@ -1,5 +1,5 @@
 {
-  "recommend_next_song": "Reference song: '{song_name}' by {artist_name}. Recommend a similar song. Respond ONLY in JSON format:\n{'track_name': '<TRACK NAME>', 'artist_name': '<ARTIST NAME>'}",
+  "recommend_next_song": "Reference song: '{song_name}' by {artist_name}. Recommend a similar song. Respond ONLY in JSON format:\n{{'track_name': '<TRACK NAME>', 'artist_name': '<ARTIST NAME>'}}",
   "recommend_next_ten_songs": "Reference song: '{song_name}' by {artist_name}. List 10 similar songs in the format:\n1. [Track Title] by [Artist Name]",
   "create_playlist": "The current song is '{song_name}' by {artist_name}. Create a playlist of 15 songs matching the same vibe.",
   "theme_based_playlist": "Create a playlist of 10 songs fitting the theme '{theme}'. Format:\n1. [Track Title] by [Artist Name]",
@@ -7,5 +7,6 @@
   "song_insights": "You are Buzz Navarro, audophile Radio Host, you know all the obscure facts and low key bands. Tell your viewers about '{song_name}' by {artist_name}. You must respond as Radio Host. Bonus points for less-known facts.",
   "lyrics_take": "You are radio host _____ {{explanation about knowledge of song lyrics}} {{instruction to explain deep meaning of song lyrics}} from {{track_name}} by {{artist_name}}",
   "explain_lyrics": "You are a thoughtful music journalist. Using the lyrics below, write a creative yet accurate interpretation of '{song_name}' by {artist_name}. Reference specific lines.\nLyrics:\n{lyrics}",
-  "auto_dj": "Current song: '{song_name}' by {artist_name}. Suggest a good follow-up track. Respond ONLY in JSON format:\n{'track_name': '<TRACK>', 'artist_name': '<ARTIST>'}"
+  "auto_dj": "Current song: '{song_name}' by {artist_name}. Suggest a good follow-up track. Respond ONLY in JSON format:\n{{'track_name': '<TRACK>', 'artist_name': '<ARTIST>'}}",
+  "dj_commentary": "We just spun '{last_song}' and coming up is '{next_song}'. Say one short line as a hype radio DJ."
 }

--- a/upnext.py
+++ b/upnext.py
@@ -215,3 +215,17 @@ class UpNextManager:
         prompt = self.templates["generate_radio_intro"].format(track_name=track_name, artist_name=artist_name)
         response = self.dj.ask(prompt)
         return response or " [DJ dead air] No intro available."
+
+    def dj_commentary(self, last_song: tuple[str, str], next_song: tuple[str, str]) -> str:
+        """Generate short DJ commentary between tracks."""
+
+        prompt = self.templates["dj_commentary"].format(
+            last_song=f"{last_song[0]} by {last_song[1]}",
+            next_song=f"{next_song[0]} by {next_song[1]}",
+        )
+        response = self.dj.ask(prompt)
+        if response:
+            self.console.print(Panel(response, title=" DJ", border_style="blue"))
+        else:
+            self.console.print("[red]No DJ commentary generated.[/red]")
+        return response or ""


### PR DESCRIPTION
## Summary
- add new `dj_commentary` prompt
- extend `UpNextManager` with `dj_commentary` helper
- call DJ commentary every third track when Auto-DJ is on

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b78257808329ae4f615e4d903b44