### PR TITLE
Add DJ settings and chatter controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ cp example.env .env
 ```
 
 Update `.env` with your Spotify Client ID, Secret, and Redirect URI.
+
+### Configuration
+
+Create a ``settings.json`` file in the project root (one is provided with
+defaults). It controls the DJ persona and chatter level:
+
+```json
+{
+  "host_name": "Buzz Navarro",
+  "intro_count": 3,
+  "chatter_level": "normal"
+}
+```
+
+- ``host_name`` – the DJ voice used in prompts
+- ``intro_count`` – how many radio intros are printed each session
+- ``chatter_level`` – ``silent`` disables intros, ``normal`` uses short intros,
+  ``talkative`` uses detailed commentary
+
 ## Optional: Using `spotifyd` on Linux
 
 On systems like Arch Linux you can run a headless Spotify client with [`spotifyd`](https://github.com/Spotifyd/spotifyd). Start `spotifyd` before running RadioFreeDJ so that the Spotify Web API has an active device to queue tracks to.

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,5 @@
+{
+  "host_name": "Buzz Navarro",
+  "intro_count": 3,
+  "chatter_level": "normal"
+}

--- a/tests/test_upnext.py
+++ b/tests/test_upnext.py
@@ -1,6 +1,8 @@
 import sys, os
+
 os.environ.setdefault("GENIUS_API_TOKEN", "dummy")
 import unittest
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from upnext import UpNextManager
@@ -11,14 +13,17 @@ class DummyDJ:
         class L:
             def info(self, *a, **k):
                 pass
+
             def warning(self, *a, **k):
                 pass
+
             def error(self, *a, **k):
                 pass
+
         self.logger = L()
 
     def ask(self, prompt):
-        return '{}'
+        return "{}"
 
 
 class DummySpotify:
@@ -53,6 +58,13 @@ class UpNextTest(unittest.TestCase):
         mgr.maintain_queue("Current", "Artist")
         self.assertEqual(len(mgr.queue), 5)
         self.assertIn(("Current", "Artist"), mgr.recent_tracks)
+
+    def test_config_loading(self):
+        cfg = {"host_name": "Sid", "intro_count": 2, "chatter_level": "talkative"}
+        mgr = UpNextManager(DummyDJ(), DummySpotify(), {}, cfg)
+        self.assertEqual(mgr.host_name, "Sid")
+        self.assertEqual(mgr.intro_count, 2)
+        self.assertEqual(mgr.chatter_level, "talkative")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- introduce `settings.json` for runtime DJ configuration
- load settings in `upnext.py`
- limit radio intros and select host prompt based on settings
- document configuration in README
- test configuration handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9e21641c8329b265232b8c5b898c