### PR TITLE
Add env template and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ pip install -r requirements.txt
 cp example.env .env
 ```
 
-Update `.env` with your Spotify Client ID, Secret, and Redirect URI.
+Edit `.env` using the keys shown in `example.env`. At minimum provide your
+Spotify credentials and `OPENAI_API_KEY`. You may also supply Last.fm
+values if you want scrobbling support.
 ## Optional: Using `spotifyd` on Linux
 
 On systems like Arch Linux you can run a headless Spotify client with [`spotifyd`](https://github.com/Spotifyd/spotifyd). Start `spotifyd` before running RadioFreeDJ so that the Spotify Web API has an active device to queue tracks to.

--- a/assets/README.md
+++ b/assets/README.md
@@ -36,7 +36,9 @@ pip install -r requirements.txt
 cp example.env .env
 ```
 
-Update `.env` with your Spotify Client ID, Secret, and Redirect URI.
+Edit `.env` using the keys shown in `example.env`. At minimum provide your
+Spotify credentials and `OPENAI_API_KEY`. You may also supply Last.fm
+values if you want scrobbling support.
 
 ---
 

--- a/example.env
+++ b/example.env
@@ -1,0 +1,15 @@
+# Copy this file to .env and populate with your credentials
+
+# Spotify credentials
+SPOTIPY_CLIENT_ID=your_spotify_client_id
+SPOTIPY_CLIENT_SECRET=your_spotify_client_secret
+SPOTIPY_REDIRECT_URI=http://localhost:8888/callback
+
+# OpenAI
+OPENAI_API_KEY=your_openai_api_key
+
+# Last.fm (optional)
+LASTFM_API_KEY=your_lastfm_api_key
+LASTFM_API_SECRET=your_lastfm_api_secret
+# LASTFM_SESSION_KEY=your_lastfm_session_key
+


### PR DESCRIPTION
## Summary
- provide `example.env` template for Spotify, Last.fm and OpenAI keys
- reference environment template in README setup instructions
- keep `.env` ignored to prevent credential leaks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9e2675b88329abc4acad93418cdc