### PR TITLE
Add Last.fm session authorization flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,11 @@ RadioFreeGPT supports optional Last.fm integration for scrobbling tracks and sub
 ```env
 LASTFM_API_KEY=your_key_here
 LASTFM_API_SECRET=your_secret_here
-LASTFM_USERNAME=your_username
-LASTFM_PASSWORD_HASH=your_password_md5
 ```
 
-To get the MD5 hash of your password (Note: this method is rather insecure and has been replaced by standard OAuth in most modern applications, do so at your own risk):
-
-```python
-import hashlib
-print(hashlib.md5("your_password".encode()).hexdigest())
-```
-
-3. The app will automatically submit track data to Last.fm when this configuration is present.
+3. Run `python main.py` once and follow the authorization link that appears.
+   After approving access, a `LASTFM_SESSION_KEY` will be stored in your `.env`
+   file for future sessions.
 
 ---
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -52,18 +52,11 @@ RadioFreeGPT supports optional Last.fm integration for scrobbling tracks and sub
 ```env
 LASTFM_API_KEY=your_key_here
 LASTFM_API_SECRET=your_secret_here
-LASTFM_USERNAME=your_username
-LASTFM_PASSWORD_HASH=your_password_md5
 ```
 
-To get the MD5 hash of your password (Note: this method is rather insecure and has been replaced by standard OAuth in most modern applications, do so at your own risk):
-
-```python
-import hashlib
-print(hashlib.md5("your_password".encode()).hexdigest())
-```
-
-3. The app will automatically submit track data to Last.fm when this configuration is present.
+3. Run `python main.py` once and follow the authorization link that appears.
+   After approving access, a `LASTFM_SESSION_KEY` will be stored in your `.env`
+   file for future sessions.
 
 ---
 

--- a/lastfm_utils.py
+++ b/lastfm_utils.py
@@ -1,3 +1,10 @@
+"""Helper functions for integrating with the Last.fm API.
+
+This module provides a thin wrapper around :mod:`pylast` for submitting
+"now playing" updates and scrobbles. It handles storing the user's
+session key so that authentication only needs to occur once.
+"""
+
 import os
 import time
 from dotenv import load_dotenv
@@ -16,38 +23,78 @@ _network = None
 
 
 def get_network():
+    """Return an authenticated :class:`pylast.LastFMNetwork` instance."""
+
     global _network
-    if _network is None:
-        if not (API_KEY and API_SECRET and SESSION_KEY):
-            logger.warning("Last.fm credentials not configured")
-            return None
+    if _network is not None:
+        return _network
+
+    if not (API_KEY and API_SECRET):
+        logger.warning("Last.fm credentials not configured")
+        return None
+
+    if SESSION_KEY:
         _network = pylast.LastFMNetwork(
             api_key=API_KEY,
             api_secret=API_SECRET,
             session_key=SESSION_KEY,
         )
+        return _network
+
+    network = pylast.LastFMNetwork(api_key=API_KEY, api_secret=API_SECRET)
+    sg = pylast.SessionKeyGenerator(network)
+    url = sg.get_web_auth_url()
+    print(f"Authorize RadioFreeGPT with Last.fm: {url}")
+    input("Press Enter after authorization...")
+    try:
+        session_key = sg.get_web_auth_session_key(url)
+    except Exception as e:  # noqa: BLE001
+        logger.error("Failed to obtain Last.fm session key: %s", e)
+        return None
+
+    os.environ["LASTFM_SESSION_KEY"] = session_key
+    try:
+        with open(".env", "a", encoding="utf-8") as env_file:
+            env_file.write(f"\nLASTFM_SESSION_KEY={session_key}\n")
+        logger.info("Stored Last.fm session key in .env")
+    except OSError as e:  # noqa: PERF203
+        logger.error("Could not save session key to .env: %s", e)
+
+    _network = pylast.LastFMNetwork(
+        api_key=API_KEY,
+        api_secret=API_SECRET,
+        session_key=session_key,
+    )
     return _network
 
 
-def update_now_playing(track_name: str, artist_name: str):
+def update_now_playing(track_name: str, artist_name: str) -> None:
+    """Submit the currently playing track to Last.fm."""
+
     network = get_network()
     if not network:
         return
     try:
         network.update_now_playing(artist=artist_name, title=track_name)
         logger.info("Updated now playing: %s - %s", artist_name, track_name)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         logger.error("Last.fm now playing error: %s", e)
 
 
-def scrobble(track_name: str, artist_name: str, timestamp: int | None = None):
+def scrobble(track_name: str, artist_name: str, timestamp: int | None = None) -> None:
+    """Record that a track finished playing on Last.fm."""
+
     network = get_network()
     if not network:
         return
     if timestamp is None:
         timestamp = int(time.time())
     try:
-        network.scrobble(artist=artist_name, title=track_name, timestamp=timestamp)
+        network.scrobble(
+            artist=artist_name,
+            title=track_name,
+            timestamp=timestamp,
+        )
         logger.info("Scrobbled: %s - %s", artist_name, track_name)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         logger.error("Last.fm scrobble error: %s", e)


### PR DESCRIPTION
## Summary
- integrate Last.fm session authorization in `get_network`
- store retrieved session key in `.env`
- document Last.fm setup with session key in README files
- add module and function docstrings for `lastfm_utils`

## Testing
- `ruff check lastfm_utils.py --fix`
- `black lastfm_utils.py --quiet`
- `mypy lastfm_utils.py --ignore-missing-imports`
- `python -m pytest -q`
- `mypy . --ignore-missing-imports` *(fails: missing stubs and type annotations)*

------
https://chatgpt.com/codex/tasks/task_e_684a9e1de8fc8329ab01a5238097328b