### PR TITLE
Add Auto-DJ batch mode

### DIFF
--- a/prompts.json
+++ b/prompts.json
@@ -9,5 +9,6 @@
   "song_insights_alt": "You are Soundscapes Sid - A radio host persona who expertly paints sonic landscapes with every broadcast. As a well spoken audophile, you know all the obscure facts and low key bands. Tell your viewers about '{song_name}' by {artist_name}. You must respond as Radio Host. Bonus points for less-known facts.",
   "explain_lyrics": "You are a thoughtful music journalist. Using the lyrics below, write a creative yet accurate interpretation of '{song_name}' by {artist_name}. Reference specific lines.\nLyrics:\n{lyrics}",
   "auto_dj": "Current song: '{song_name}' by {artist_name}. Suggest a good follow-up track. Respond ONLY in JSON format:\n{{'track_name': '<TRACK>', 'artist_name': '<ARTIST>'}}",
+  "auto_dj_batch": "Current song: '{song_name}' by {artist_name}'. Suggest five follow-up tracks. Respond ONLY in JSON list format: [{\"track_name\": \"<TRACK>\", \"artist_name\": \"<ARTIST>\", \"intro\": \"<SHORT INTRO>\"}]",
   "dj_commentary": "We just spun '{last_song}' and coming up is '{next_song}'. Say one short line as a hype radio DJ."
 }

--- a/tests/test_upnext.py
+++ b/tests/test_upnext.py
@@ -1,6 +1,9 @@
 import sys, os
+
 os.environ.setdefault("GENIUS_API_TOKEN", "dummy")
 import unittest
+import json
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from upnext import UpNextManager
@@ -11,14 +14,28 @@ class DummyDJ:
         class L:
             def info(self, *a, **k):
                 pass
+
             def warning(self, *a, **k):
                 pass
+
             def error(self, *a, **k):
                 pass
+
         self.logger = L()
 
     def ask(self, prompt):
-        return '{}'
+        return "{}"
+
+
+class BatchDJ(DummyDJ):
+    def __init__(self, response):
+        super().__init__()
+        self.calls = 0
+        self.response = response
+
+    def ask(self, prompt):
+        self.calls += 1
+        return self.response
 
 
 class DummySpotify:
@@ -29,6 +46,14 @@ class DummySpotify:
         pass
 
 
+class CaptureSpotify(DummySpotify):
+    def __init__(self):
+        self.added = []
+
+    def add_to_queue(self, uri):
+        self.added.append(uri)
+
+
 class UpNextTest(unittest.TestCase):
     def test_recent_track_skip(self):
         mgr = UpNextManager(DummyDJ(), DummySpotify(), {})
@@ -37,22 +62,36 @@ class UpNextTest(unittest.TestCase):
         self.assertFalse(added)
 
     def test_maintain_queue_caps_length(self):
-        mgr = UpNextManager(DummyDJ(), DummySpotify(), {})
+        response = json.dumps(
+            [
+                {"track_name": f"Song{i}", "artist_name": f"Artist{i}", "intro": ""}
+                for i in range(6)
+            ]
+        )
+        dj = BatchDJ(response)
+        sp = CaptureSpotify()
+        mgr = UpNextManager(dj, sp, {"auto_dj_batch": ""})
         mgr.auto_dj_enabled = True
-        tracks = [(f"Song{i}", f"Artist{i}") for i in range(6)]
-        gen = (t for t in tracks)
-
-        def fake_auto_dj(curr_song, curr_artist):
-            try:
-                t = next(gen)
-            except StopIteration:
-                return False
-            return mgr._queue_track(*t)
-
-        mgr.auto_dj_transition = fake_auto_dj
         mgr.maintain_queue("Current", "Artist")
         self.assertEqual(len(mgr.queue), 5)
+        self.assertEqual(dj.calls, 1)
         self.assertIn(("Current", "Artist"), mgr.recent_tracks)
+
+    def test_batch_called_once(self):
+        response = json.dumps(
+            [
+                {"track_name": "Song1", "artist_name": "Artist1", "intro": "hi"},
+                {"track_name": "Song2", "artist_name": "Artist2", "intro": "hi"},
+            ]
+        )
+        dj = BatchDJ(response)
+        sp = CaptureSpotify()
+        mgr = UpNextManager(dj, sp, {"auto_dj_batch": ""})
+        mgr.auto_dj_enabled = True
+        mgr.maintain_queue("Song0", "Artist0")
+        self.assertEqual(dj.calls, 1)
+        mgr.maintain_queue("Song0", "Artist0")
+        self.assertEqual(dj.calls, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `auto_dj_batch` prompt
- queue a batch of tracks when Auto-DJ starts
- parse batch responses and print provided intros
- update `UpNextManager` tests for batch behaviour

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9e202da48329b86cef5642ef4e57