### PR TITLE
Add Auto-DJ batch mode

### DIFF
--- a/prompts.json
+++ b/prompts.json
@@ -9,5 +9,6 @@
   "song_insights_alt": "You are Soundscapes Sid - A radio host persona who expertly paints sonic landscapes with every broadcast. As a well spoken audophile, you know all the obscure facts and low key bands. Tell your viewers about '{song_name}' by {artist_name}. You must respond as Radio Host. Bonus points for less-known facts.",
   "explain_lyrics": "You are a thoughtful music journalist. Using the lyrics below, write a creative yet accurate interpretation of '{song_name}' by {artist_name}. Reference specific lines.\nLyrics:\n{lyrics}",
   "auto_dj": "Current song: '{song_name}' by {artist_name}. Suggest a good follow-up track. Respond ONLY in JSON format:\n{{'track_name': '<TRACK>', 'artist_name': '<ARTIST>'}}",
+  "auto_dj_batch": "Current song: '{song_name}' by {artist_name}'. Suggest five follow-up tracks. Respond ONLY in JSON list format: [{\"track_name\": \"<TRACK>\", \"artist_name\": \"<ARTIST>\", \"intro\": \"<SHORT INTRO>\"}]",
   "dj_commentary": "We just spun '{last_song}' and coming up is '{next_song}'. Say one short line as a hype radio DJ."
 }

--- a/tests/test_upnext.py
+++ b/tests/test_upnext.py
@@ -1,6 +1,9 @@
 import sys, os
+
 os.environ.setdefault("GENIUS_API_TOKEN", "dummy")
 import unittest
+import json
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from upnext import UpNextManager
@@ -11,14 +14,28 @@ class DummyDJ:
         class L:
             def info(self, *a, **k):
                 pass
+
             def warning(self, *a, **k):
                 pass
+
             def error(self, *a, **k):
                 pass
+
         self.logger = L()
 
     def ask(self, prompt):
-        return '{}'
+        return "{}"
+
+
+class BatchDJ(DummyDJ):
+    def __init__(self, response):
+        super().__init__()
+        self.calls = 0
+        self.response = response
+
+    def ask(self, prompt):
+        self.calls += 1
+        return self.response
 
 
 class DummySpotify:
@@ -29,6 +46,14 @@ class DummySpotify:
         pass
 
 
+class CaptureSpotify(DummySpotify):
+    def __init__(self):
+        self.added = []
+
+    def add_to_queue(self, uri):
+        self.added.append(uri)
+
+
 class UpNextTest(unittest.TestCase):
     def test_recent_track_skip(self):
         mgr = UpNextManager(DummyDJ(), DummySpotify(), {})
@@ -37,22 +62,36 @@ class UpNextTest(unittest.TestCase):
         self.assertFalse(added)
 
     def test_maintain_queue_caps_length(self):
-        mgr = UpNextManager(DummyDJ(), DummySpotify(), {})
+        response = json.dumps(
+            [
+                {"track_name": f"Song{i}", "artist_name": f"Artist{i}", "intro": ""}
+                for i in range(6)
+            ]
+        )
+        dj = BatchDJ(response)
+        sp = CaptureSpotify()
+        mgr = UpNextManager(dj, sp, {"auto_dj_batch": ""})
         mgr.auto_dj_enabled = True
-        tracks = [(f"Song{i}", f"Artist{i}") for i in range(6)]
-        gen = (t for t in tracks)
-
-        def fake_auto_dj(curr_song, curr_artist):
-            try:
-                t = next(gen)
-            except StopIteration:
-                return False
-            return mgr._queue_track(*t)
-
-        mgr.auto_dj_transition = fake_auto_dj
         mgr.maintain_queue("Current", "Artist")
         self.assertEqual(len(mgr.queue), 5)
+        self.assertEqual(dj.calls, 1)
         self.assertIn(("Current", "Artist"), mgr.recent_tracks)
+
+    def test_batch_called_once(self):
+        response = json.dumps(
+            [
+                {"track_name": "Song1", "artist_name": "Artist1", "intro": "hi"},
+                {"track_name": "Song2", "artist_name": "Artist2", "intro": "hi"},
+            ]
+        )
+        dj = BatchDJ(response)
+        sp = CaptureSpotify()
+        mgr = UpNextManager(dj, sp, {"auto_dj_batch": ""})
+        mgr.auto_dj_enabled = True
+        mgr.maintain_queue("Song0", "Artist0")
+        self.assertEqual(dj.calls, 1)
+        mgr.maintain_queue("Song0", "Artist0")
+        self.assertEqual(dj.calls, 1)
 
 
 if __name__ == "__main__":

--- a/upnext.py
+++ b/upnext.py
@@ -4,7 +4,6 @@ import json
 from gpt_utils import parse_json_response
 from rich.console import Console
 from rich.panel import Panel
-from rich.text import Text
 from rich.prompt import Prompt
 from genius_utils import get_lyrics
 
@@ -41,31 +40,6 @@ class UpNextManager:
         uri = self.sp.search_track(track_name, artist_name)
         if uri:
             self.sp.add_to_queue(uri)
-            self.queue.append(
-                {"track_name": track_name, "artist_name": artist_name}
-            )
-            self.dj.logger.info(f"Queued track: {track_name} by {artist_name}")
-            return True
-        self.dj.logger.warning(
-            f"Track not found for queueing: {track_name} by {artist_name}"
-        )
-        return False
-
-    def show_queue(self):
-        if not self.queue:
-            self.console.print("[dim]Queue is empty.[/dim]")
-            return
-        lines = [
-            f"{i}. {t['track_name']} - {t['artist_name']}"
-            for i, t in enumerate(self.queue, 1)
-        ]
-        self.console.print(Panel("\n".join(lines), title="Up Next", border_style="blue"))
-
-    def _queue_track(self, track_name: str, artist_name: str) -> bool:
-        """Search Spotify and queue the track if found."""
-        uri = self.sp.search_track(track_name, artist_name)
-        if uri:
-            self.sp.add_to_queue(uri)
             self.queue.append({"track_name": track_name, "artist_name": artist_name})
             self.dj.logger.info(f"Queued track: {track_name} by {artist_name}")
             return True
@@ -82,56 +56,21 @@ class UpNextManager:
             f"{i}. {t['track_name']} - {t['artist_name']}"
             for i, t in enumerate(self.queue, 1)
         ]
-        self.console.print(Panel("\n".join(lines), title="Up Next", border_style="blue"))
-
-    def _queue_track(self, track_name: str, artist_name: str) -> bool:
-        """Search Spotify and queue the track if found."""
-        if not track_name or not artist_name:
-            return False
-        if (track_name, artist_name) in self.recent_tracks:
-            self.dj.logger.info(
-                f"Skipping recently played track: {track_name} by {artist_name}"
-            )
-            return False
-        if any(
-            t["track_name"] == track_name and t["artist_name"] == artist_name
-            for t in self.queue
-        ):
-            return False
-        uri = self.sp.search_track(track_name, artist_name)
-        if uri:
-            self.sp.add_to_queue(uri)
-            self.queue.append(
-                {"track_name": track_name, "artist_name": artist_name}
-            )
-            self.dj.logger.info(f"Queued track: {track_name} by {artist_name}")
-            return True
-        self.dj.logger.warning(
-            f"Track not found for queueing: {track_name} by {artist_name}"
+        self.console.print(
+            Panel("\n".join(lines), title="Up Next", border_style="blue")
         )
-        return False
 
-    def show_queue(self):
-        if not self.queue:
-            self.console.print("[dim]Queue is empty.[/dim]")
-            return
-        lines = [
-            f"{i}. {t['track_name']} - {t['artist_name']}"
-            for i, t in enumerate(self.queue, 1)
-        ]
-        self.console.print(Panel("\n".join(lines), title="Up Next", border_style="blue"))
 
     def toggle_playlist_mode(self):
         self.mode = "playlist" if self.mode == "smart" else "smart"
-        self.console.print(Panel(f"[bold cyan]Switched to [green]{self.mode}[/green] mode.[/bold cyan]"))
+        self.console.print(
+            Panel(
+                f"[bold cyan]Switched to [green]{self.mode}[/green] mode.[/bold cyan]"
+            )
+        )
 
     def maintain_queue(self, current_song: str, current_artist: str) -> None:
-        """Fill the queue when auto-DJ mode is enabled.
-
-        The currently playing track is recorded to avoid immediate repeats.
-        Additional recommendations are queued until five songs are
-        pending or a recommendation fails.
-        """
+        """Ensure the queue is populated when Auto-DJ mode is active."""
 
         if current_song and current_artist:
             track = (current_song, current_artist)
@@ -140,15 +79,21 @@ class UpNextManager:
                 if len(self.recent_tracks) > 100:
                     self.recent_tracks.pop(0)
 
-        while self.auto_dj_enabled and len(self.queue) < 5:
-            if not self.auto_dj_transition(current_song, current_artist):
-                break
+        if (
+            self.auto_dj_enabled
+            and not self.queue
+            and current_song
+            and current_artist
+        ):
+            self._auto_dj_batch(current_song, current_artist)
 
         if len(self.queue) > 5:
             self.queue = self.queue[-5:]
 
     def auto_dj_transition(self, current_song, current_artist) -> bool:
-        prompt = self.templates["auto_dj"].format(song_name=current_song, artist_name=current_artist)
+        prompt = self.templates["auto_dj"].format(
+            song_name=current_song, artist_name=current_artist
+        )
         resp = self.dj.ask(prompt)
         self.dj.logger.info(f"[auto_dj_transition] Prompt:\n{prompt}")
         self.dj.logger.info(f"[auto_dj_transition] Raw Response:\n{resp}")
@@ -174,8 +119,43 @@ class UpNextManager:
             self.dj.logger.error(f"Error parsing GPT response as JSON: {e}")
         return False
 
+    def _auto_dj_batch(self, current_song: str, current_artist: str) -> None:
+        """Queue a batch of tracks returned by the GPT Auto-DJ."""
+
+        if not current_song or not current_artist:
+            return
+
+        prompt = self.templates["auto_dj_batch"].format(
+            song_name=current_song, artist_name=current_artist
+        )
+        resp = self.dj.ask(prompt)
+        self.dj.logger.info(f"[auto_dj_batch] Prompt:\n{prompt}")
+        self.dj.logger.info(f"[auto_dj_batch] Raw Response:\n{resp}")
+
+        try:
+            items = json.loads(resp)
+            if isinstance(items, dict):
+                items = [items]
+        except Exception as e:
+            self.dj.logger.error(f"Error parsing GPT batch response: {e}")
+            return
+
+        for item in items:
+            track_name = item.get("track_name")
+            artist_name = item.get("artist_name")
+            intro = item.get("intro")
+            if self._queue_track(track_name, artist_name):
+                if intro:
+                    self.console.print(
+                        Panel(intro, title=" DJ Intro", border_style="blue")
+                    )
+            if len(self.queue) >= 5:
+                break
+
     def queue_one_song(self, song_name, artist_name):
-        prompt = self.templates["recommend_next_song"].format(song_name=song_name, artist_name=artist_name)
+        prompt = self.templates["recommend_next_song"].format(
+            song_name=song_name, artist_name=artist_name
+        )
         response = self.dj.ask(prompt)
         if not response:
             self.console.print("[red]No song queued.[/red]")
@@ -198,7 +178,9 @@ class UpNextManager:
         self.show_queue()
 
     def queue_ten_songs(self, song_name, artist_name):
-        prompt = self.templates["recommend_next_ten_songs"].format(song_name=song_name, artist_name=artist_name)
+        prompt = self.templates["recommend_next_ten_songs"].format(
+            song_name=song_name, artist_name=artist_name
+        )
         response = self.dj.ask(prompt)
         if not response:
             self.console.print("[red]No songs queued.[/red]")
@@ -219,7 +201,9 @@ class UpNextManager:
         self.show_queue()
 
     def queue_playlist(self, song_name, artist_name):
-        prompt = self.templates["create_playlist"].format(song_name=song_name, artist_name=artist_name)
+        prompt = self.templates["create_playlist"].format(
+            song_name=song_name, artist_name=artist_name
+        )
         self._parse_and_queue_playlist(prompt)
 
     def queue_theme_playlist(self):
@@ -249,7 +233,9 @@ class UpNextManager:
         self.show_queue()
 
     def song_insight(self, song_name, artist_name):
-        prompt = self.templates["song_insights"].format(song_name=song_name, artist_name=artist_name)
+        prompt = self.templates["song_insights"].format(
+            song_name=song_name, artist_name=artist_name
+        )
         response = self.dj.ask(prompt)
         if response:
             self.console.print(Panel(response, title=" Insight", border_style="cyan"))
@@ -267,16 +253,22 @@ class UpNextManager:
         )
         response = self.dj.ask(prompt)
         if response:
-            self.console.print(Panel(response, title=" Lyric Breakdown", border_style="cyan"))
+            self.console.print(
+                Panel(response, title=" Lyric Breakdown", border_style="cyan")
+            )
         else:
             self.console.print("[red]No lyric explanation generated.[/red]")
 
     def _generate_radio_intro(self, track_name, artist_name):
-        prompt = self.templates["generate_radio_intro"].format(track_name=track_name, artist_name=artist_name)
+        prompt = self.templates["generate_radio_intro"].format(
+            track_name=track_name, artist_name=artist_name
+        )
         response = self.dj.ask(prompt)
         return response or " [DJ dead air] No intro available."
 
-    def dj_commentary(self, last_song: tuple[str, str], next_song: tuple[str, str]) -> str:
+    def dj_commentary(
+        self, last_song: tuple[str, str], next_song: tuple[str, str]
+    ) -> str:
         """Generate short DJ commentary between tracks."""
 
         prompt = self.templates["dj_commentary"].format(


### PR DESCRIPTION
## Summary
- add `auto_dj_batch` prompt
- queue a batch of tracks when Auto-DJ starts
- parse batch responses and print provided intros
- update `UpNextManager` tests for batch behaviour
- handle empty track cases and remove duplicate functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a9e202da48329b86cef5642ef4e57