### PR TITLE
Remove duplicate queue methods

### DIFF
--- a/upnext.py
+++ b/upnext.py
@@ -80,67 +80,7 @@ class UpNextManager:
         return False
 
     def show_queue(self):
-        if not self.queue:
-            self.console.print("[dim]Queue is empty.[/dim]")
-            return
-        lines = [
-            f"{i}. {t['track_name']} - {t['artist_name']}"
-            for i, t in enumerate(self.queue, 1)
-        ]
-        self.console.print(
-            Panel("\n".join(lines), title="Up Next", border_style="blue")
-        )
-
-    def _queue_track(self, track_name: str, artist_name: str) -> bool:
-        """Search Spotify and queue the track if found."""
-        uri = self.sp.search_track(track_name, artist_name)
-        if uri:
-            self.sp.add_to_queue(uri)
-            self.queue.append({"track_name": track_name, "artist_name": artist_name})
-            self.dj.logger.info(f"Queued track: {track_name} by {artist_name}")
-            return True
-        self.dj.logger.warning(
-            f"Track not found for queueing: {track_name} by {artist_name}"
-        )
-        return False
-
-    def show_queue(self):
-        if not self.queue:
-            self.console.print("[dim]Queue is empty.[/dim]")
-            return
-        lines = [
-            f"{i}. {t['track_name']} - {t['artist_name']}"
-            for i, t in enumerate(self.queue, 1)
-        ]
-        self.console.print(
-            Panel("\n".join(lines), title="Up Next", border_style="blue")
-        )
-
-    def _queue_track(self, track_name: str, artist_name: str) -> bool:
-        """Search Spotify and queue the track if found."""
-        if not track_name or not artist_name:
-            return False
-        if (track_name, artist_name) in self.recent_tracks:
-            self.dj.logger.info(
-                f"Skipping recently played track: {track_name} by {artist_name}"
-            )
-            return False
-        if any(
-            t["track_name"] == track_name and t["artist_name"] == artist_name
-            for t in self.queue
-        ):
-            return False
-        uri = self.sp.search_track(track_name, artist_name)
-        if uri:
-            self.sp.add_to_queue(uri)
-            self.queue.append({"track_name": track_name, "artist_name": artist_name})
-            self.dj.logger.info(f"Queued track: {track_name} by {artist_name}")
-            return True
-        self.dj.logger.warning(
-            f"Track not found for queueing: {track_name} by {artist_name}"
-        )
-
-    def show_queue(self):
+        """Display the currently queued tracks."""
         if not self.queue:
             self.console.print("[dim]Queue is empty.[/dim]")
             return
@@ -170,12 +110,7 @@ class UpNextManager:
                 if len(self.recent_tracks) > 100:
                     self.recent_tracks.pop(0)
 
-        if (
-            self.auto_dj_enabled
-            and not self.queue
-            and current_song
-            and current_artist
-        ):
+        if self.auto_dj_enabled and not self.queue and current_song and current_artist:
             self._auto_dj_batch(current_song, current_artist)
 
         if len(self.queue) > 5:


### PR DESCRIPTION
## Summary
- deduplicate `_queue_track` and `show_queue` implementations in `upnext.py`
- document `show_queue`

## Testing
- `ruff check upnext.py`
- `black --check upnext.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68518c272d4c8329ad1ca4ab4a52eaa1