### PR TITLE
Add restart and skip-to-end controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Spotify integration for playback and control
 - Terminal graphics using `rich` and `textual`
 - AI-generated playlists, transitions, and chat
+- Fine-grained playback controls including restart and skip to end
 - Modular design with plugin support for show scripts
 
 ---

--- a/main.py
+++ b/main.py
@@ -53,6 +53,8 @@ COMMAND_LABELS = {
     "5": "Queue Theme Playlist",
     "6": "Song Insight",
     "7": "Lyric Breakdown",
+    "b": "Restart Track",
+    "e": "Skip to End",
     "t": "Toggle Mode",
     "0": "Quit",
     "l": "Toggle Lyrics View",
@@ -217,6 +219,8 @@ def get_menu_text():
         "[bold]5.[/bold] Queue 10-song theme playlist",
         "[bold]6.[/bold] Get info on current song",
         "[bold]7.[/bold] Explain current song lyrics",
+        "[bold]b.[/bold] Restart current song",
+        "[bold]e.[/bold] Skip to song end",
         f"[bold]t.[/bold] Toggle playback mode ({mode_label} Mode)",
         "[bold]0.[/bold] Quit",
     ]
@@ -413,6 +417,12 @@ def process_user_input(choice: str, current_song: str, current_artist: str):
         upnext.song_insight(current_song, current_artist)
     elif choice == "7":
         upnext.explain_lyrics(current_song, current_artist)
+    elif choice == "b":
+        spotify_controller.restart_track()
+        notify("↩ Restarted track.", style="yellow")
+    elif choice == "e":
+        spotify_controller.skip_to_end()
+        notify("⏭ Skipped to end of track.", style="yellow")
     elif choice == "t":
         upnext.toggle_playlist_mode()
         notify(

--- a/spotify_utils.py
+++ b/spotify_utils.py
@@ -119,3 +119,22 @@ class SpotifyController:
             self.logger.info("Volume set to %d%%", new_vol)
         except Exception as e:
             self.logger.error("Error changing volume: %s", e)
+
+    def restart_track(self) -> None:
+        """Restart playback from the beginning of the current track."""
+        try:
+            self.sp.seek_track(0)
+        except Exception as e:
+            self.logger.error("Error restarting track: %s", e)
+
+    def skip_to_end(self) -> None:
+        """Seek to the final second of the current track to move to the next."""
+        try:
+            playback = self.sp.current_playback()
+            duration = playback.get("item", {}).get("duration_ms", 0) if playback else 0
+            if duration > 1000:
+                self.sp.seek_track(duration - 1000)
+            else:
+                self.next()
+        except Exception as e:
+            self.logger.error("Error skipping to end: %s", e)

--- a/tests/test_spotify_utils.py
+++ b/tests/test_spotify_utils.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import MagicMock
+
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from spotify_utils import SpotifyController
+
+class SpotifyControllerTest(unittest.TestCase):
+    def setUp(self):
+        self.ctrl = SpotifyController.__new__(SpotifyController)
+        self.ctrl.sp = MagicMock()
+        self.ctrl.logger = MagicMock()
+
+    def test_restart_track_calls_seek(self):
+        self.ctrl.restart_track()
+        self.ctrl.sp.seek_track.assert_called_with(0)
+
+    def test_skip_to_end_uses_duration(self):
+        self.ctrl.sp.current_playback.return_value = {"item": {"duration_ms": 10000}}
+        self.ctrl.skip_to_end()
+        self.ctrl.sp.seek_track.assert_called_with(9000)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new methods to SpotifyController for restarting a track or jumping to the end
- expose new `b` and `e` commands in the menu for restart and skip-to-end
- update README with playback control note
- test SpotifyController restart and skip-to-end helpers

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6873a9cfb1688329ac5c7cb7dbef075f