### PR TITLE
Add GPT-driven mystery crate mode

### DIFF
--- a/mystery_mode.py
+++ b/mystery_mode.py
@@ -1,0 +1,196 @@
+"""Mystery recommendation mode for surfacing five secret song options.
+
+This module defines :class:`MysteryModeManager`, a coordinator that queries
+GPT for five similar tracks whenever the currently playing song changes. The
+manager keeps GPT's chosen follow-up track hidden from the listener while still
+queuing it on Spotify, and exposes helpers for rendering a neutral list of
+options as well as locking in a listener's manual choice.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+@dataclass(slots=True)
+class MysteryTrack:
+    """Container describing a mystery mode recommendation."""
+
+    track_name: str
+    artist_name: str
+    uri: str | None
+
+
+class MysteryModeManager:
+    """Coordinate GPT-powered mystery recommendations for the next track."""
+
+    def __init__(
+        self,
+        gpt_dj: Any,
+        spotify_controller: Any,
+        prompt_template: str,
+    ) -> None:
+        """Initialize the manager with GPT and Spotify helpers."""
+
+        self.dj = gpt_dj
+        self.sp = spotify_controller
+        self.prompt_template = prompt_template
+        self.enabled: bool = False
+        self._awaiting_choice: bool = False
+        self._choices: list[MysteryTrack] = []
+        self._selected_index: int | None = None
+
+    @property
+    def awaiting_choice(self) -> bool:
+        """Return ``True`` when the UI should capture numeric selections."""
+
+        return self._awaiting_choice
+
+    @property
+    def choice_count(self) -> int:
+        """Return the number of active options in the current mystery round."""
+
+        return len(self._choices)
+
+    def clear_choices(self) -> None:
+        """Reset any outstanding GPT choices so regular keybinds resume."""
+
+        self._choices.clear()
+        self._selected_index = None
+        self._awaiting_choice = False
+
+    def toggle(self) -> bool:
+        """Toggle mystery mode on/off, clearing pending choices if disabled."""
+
+        self.enabled = not self.enabled
+        if not self.enabled:
+            self.clear_choices()
+        return self.enabled
+
+    def activate_round(
+        self,
+        song_name: str,
+        artist_name: str,
+        cancel_event: Any | None = None,
+    ) -> str | None:
+        """Fetch five follow-up tracks for ``song_name``/``artist_name``.
+
+        Returns a sanitized Rich markup string safe for user display or ``None``
+        if the GPT call failed or produced no valid options.
+        """
+
+        if not self.enabled or not self.prompt_template:
+            return None
+
+        prompt = self.prompt_template.format(
+            song_name=song_name,
+            artist_name=artist_name,
+        )
+        if cancel_event is not None:
+            cancel_event.clear()
+        response = self.dj.ask(prompt, cancel_event=cancel_event)
+        if not response:
+            self.dj.logger.warning("Mystery mode: no response from GPT")
+            self.clear_choices()
+            return None
+
+        try:
+            parsed = json.loads(response)
+        except json.JSONDecodeError as exc:
+            self.dj.logger.error("Mystery mode JSON parse error: %s", exc)
+            self.clear_choices()
+            return None
+
+        options = self._extract_options(parsed)
+        selected_index = self._extract_selected_index(parsed)
+        if not options:
+            self.dj.logger.warning("Mystery mode: GPT returned no options")
+            self.clear_choices()
+            return None
+
+        self._choices = []
+        for option in options[:5]:
+            name = option.get("track_name")
+            artist = option.get("artist_name")
+            if not name or not artist:
+                continue
+            uri = self.sp.search_track(name, artist)
+            self._choices.append(MysteryTrack(name, artist, uri))
+
+        if not self._choices:
+            self.dj.logger.warning("Mystery mode: no playable Spotify tracks")
+            self.clear_choices()
+            return None
+
+        self._selected_index = (
+            selected_index if selected_index is not None else None
+        )
+        if (
+            self._selected_index is not None
+            and 0 <= self._selected_index < len(self._choices)
+        ):
+            uri = self._choices[self._selected_index].uri
+            if uri:
+                self.sp.add_to_queue(uri)
+            else:
+                self.dj.logger.warning(
+                    "Mystery mode: GPT-selected track missing Spotify URI"
+                )
+
+        self._awaiting_choice = True
+        return self._build_display_text()
+
+    def play_choice(self, selection_index: int) -> tuple[bool, str]:
+        """Play the listener's chosen track immediately."""
+
+        if not self._awaiting_choice:
+            return False, "No mystery selection pending."
+
+        zero_index = selection_index - 1
+        if zero_index < 0 or zero_index >= len(self._choices):
+            return False, "Invalid selection."
+
+        choice = self._choices[zero_index]
+        if not choice.uri:
+            return False, "Selected track is unavailable on Spotify."
+
+        self.sp.play_track(choice.uri)
+        self.clear_choices()
+        return True, f"Now playing {choice.track_name} by {choice.artist_name}."
+
+    def _extract_options(self, parsed: Any) -> Iterable[dict[str, Any]]:
+        """Return the list of options from an arbitrary GPT response."""
+
+        if isinstance(parsed, dict):
+            options = parsed.get("options")
+            if isinstance(options, list):
+                return options
+        if isinstance(parsed, list):
+            return parsed
+        return []
+
+    def _extract_selected_index(self, parsed: Any) -> int | None:
+        """Return the zero-based index GPT marked as its secret choice."""
+
+        if isinstance(parsed, dict):
+            raw_index = parsed.get("selected_index")
+            if isinstance(raw_index, int):
+                # ``selected_index`` is expected to be 1-based for readability.
+                return raw_index - 1 if raw_index > 0 else raw_index
+        return None
+
+    def _build_display_text(self) -> str:
+        """Return Rich markup summarising GPT's options without spoilers."""
+
+        lines = ["[bold]Mystery Crate Picks[/bold]"]
+        for idx, track in enumerate(self._choices, start=1):
+            availability = "" if track.uri else " [dim](unavailable)[/dim]"
+            lines.append(
+                f"{idx}. {track.track_name} — {track.artist_name}{availability}"
+            )
+        lines.append("")
+        lines.append("[dim]Press 1-5 to choose the next track.[/dim]")
+        return "\n".join(lines)
+

--- a/prompts.json
+++ b/prompts.json
@@ -10,5 +10,6 @@
   "explain_lyrics": "You are a thoughtful music journalist. Using the lyrics below, write a creative yet accurate interpretation of '{song_name}' by {artist_name}. Reference specific lines.\nLyrics:\n{lyrics}",
   "auto_dj": "Current song: '{song_name}' by {artist_name}. Suggest a good follow-up track. Respond ONLY in JSON format:\n{{'track_name': '<TRACK>', 'artist_name': '<ARTIST>'}}",
   "auto_dj_batch": "Current song: '{song_name}' by {artist_name}'. Suggest five follow-up tracks. Respond ONLY in JSON list format: [{\"track_name\": \"<TRACK>\", \"artist_name\": \"<ARTIST>\", \"intro\": \"<SHORT INTRO>\"}]",
+  "mystery_crate": "We just played '{song_name}' by {artist_name}. Suggest exactly five similar songs. Respond ONLY as JSON with keys: options (list of five objects with track_name and artist_name), selected_index (1-5 for the song you secretly queued next), and optional commentary. Keep the commentary generic and do not reveal which song was selected.",
   "dj_commentary": "We just spun '{last_song}' and coming up is '{next_song}'. Say one short line as a hype radio DJ."
 }

--- a/tests/test_mystery_mode.py
+++ b/tests/test_mystery_mode.py
@@ -1,0 +1,111 @@
+import json
+import os
+import sys
+import unittest
+
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from mystery_mode import MysteryModeManager
+
+
+class DummyLogger:
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+class DummyDJ:
+    def __init__(self, response: str):
+        self.response = response
+        self.logger = DummyLogger()
+
+    def ask(self, prompt, cancel_event=None):
+        return self.response
+
+
+class DummySpotify:
+    def __init__(self):
+        self.queued: list[str] = []
+        self.played: list[str] = []
+
+    def search_track(self, track, artist):
+        return f"uri:{track}:{artist}"
+
+    def add_to_queue(self, uri):
+        self.queued.append(uri)
+
+    def play_track(self, uri):
+        self.played.append(uri)
+
+
+class MysteryModeManagerTest(unittest.TestCase):
+    def test_activate_round_queues_secret_pick(self):
+        response = json.dumps(
+            {
+                "options": [
+                    {"track_name": "Song A", "artist_name": "Artist A"},
+                    {"track_name": "Song B", "artist_name": "Artist B"},
+                    {"track_name": "Song C", "artist_name": "Artist C"},
+                    {"track_name": "Song D", "artist_name": "Artist D"},
+                    {"track_name": "Song E", "artist_name": "Artist E"},
+                ],
+                "selected_index": 2,
+            }
+        )
+        dj = DummyDJ(response)
+        sp = DummySpotify()
+        manager = MysteryModeManager(dj, sp, "{song_name} - {artist_name}")
+        manager.enabled = True
+
+        display = manager.activate_round("Now", "Artist")
+
+        self.assertIsNotNone(display)
+        self.assertIn("1. Song A", display)
+        self.assertNotIn("selected_index", display)
+        self.assertTrue(manager.awaiting_choice)
+        self.assertEqual(sp.queued, ["uri:Song B:Artist B"])
+
+    def test_play_choice_starts_selected_track(self):
+        response = json.dumps(
+            {
+                "options": [
+                    {"track_name": "Song A", "artist_name": "Artist A"},
+                    {"track_name": "Song B", "artist_name": "Artist B"},
+                    {"track_name": "Song C", "artist_name": "Artist C"},
+                    {"track_name": "Song D", "artist_name": "Artist D"},
+                    {"track_name": "Song E", "artist_name": "Artist E"},
+                ],
+                "selected_index": 1,
+            }
+        )
+        dj = DummyDJ(response)
+        sp = DummySpotify()
+        manager = MysteryModeManager(dj, sp, "{song_name} - {artist_name}")
+        manager.enabled = True
+        manager.activate_round("Now", "Artist")
+
+        success, message = manager.play_choice(3)
+
+        self.assertTrue(success)
+        self.assertIn("Song C", message)
+        self.assertFalse(manager.awaiting_choice)
+        self.assertEqual(sp.played, ["uri:Song C:Artist C"])
+
+    def test_activate_round_handles_bad_json(self):
+        dj = DummyDJ("not json")
+        sp = DummySpotify()
+        manager = MysteryModeManager(dj, sp, "{song_name}")
+        manager.enabled = True
+
+        display = manager.activate_round("Now", "Artist")
+
+        self.assertIsNone(display)
+        self.assertFalse(manager.awaiting_choice)
+        self.assertEqual(sp.queued, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce a MysteryModeManager that hides GPT's secret pick while presenting five similar tracks
- integrate the new mode into the main TUI with a toggle, numeric overrides, and sanitized GPT logging
- capture a mystery-specific prompt template and regression tests for the manager

## Testing
- pytest --cov *(fails: plugin not available in environment)*
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d630b563748329bc031b093e6fa404